### PR TITLE
    Fix the issues when deploy app with mongodb service with new bluemix build

### DIFF
--- a/python/mongo-app.py
+++ b/python/mongo-app.py
@@ -33,7 +33,11 @@ if os.environ.has_key('VCAP_SERVICES'):
         mongoServices = filter(lambda s: s['name'] == 'todo-mongo-db', value)
         if len(mongoServices) != 0:
             mongoService = mongoServices[0]
-            url = mongoService['credentials']['uri']
+            if "uri" in mongoService['credentials']:
+                url = mongoService['credentials']['uri']
+            else:
+                url = mongoService['credentials']['url']
+
 
 client = MongoClient(url)
 db = client.get_default_database()


### PR DESCRIPTION
    Under Bluemix 210002, mongodb service return credentials to APPS does not contain of uri, changing to
    url, perhaps the early version returns uri keyword.